### PR TITLE
fixes ts error for mongoose-paginate-v2

### DIFF
--- a/types/mongoose-paginate-v2/index.d.ts
+++ b/types/mongoose-paginate-v2/index.d.ts
@@ -67,8 +67,8 @@ declare module 'mongoose' {
         limit: number;
         page?: number;
         totalPages: number;
-        nextPage?: number | null;
-        prevPage?: number | null;
+        nextPage?: number | boolean;
+        prevPage?: number | boolean;
         pagingCounter: number;
         hasPrevPage: boolean;
         hasNextPage: boolean;

--- a/types/mongoose-paginate-v2/index.d.ts
+++ b/types/mongoose-paginate-v2/index.d.ts
@@ -67,13 +67,13 @@ declare module 'mongoose' {
         limit: number;
         page?: number;
         totalPages: number;
-        nextPage?: number | boolean;
-        prevPage?: number | boolean;
+        nextPage?: number | null;
+        prevPage?: number | null;
         pagingCounter: number;
         hasPrevPage: boolean;
         hasNextPage: boolean;
         meta?: any;
-        [customLabel: string]: T[] | number | boolean | undefined;
+        [customLabel: string]: T[] | number | boolean | null | undefined;
     }
 
     interface PaginateModel<T extends Document> extends Model<T> {


### PR DESCRIPTION
Fixes the following error:
`Property 'prevPage' of type 'number | null | undefined' is not assignable to string index type 'number | boolean | T[] | undefined'.`
`Property 'nextPage' of type 'number | null | undefined' is not assignable to string index type 'number | boolean | T[] | undefined'.`
